### PR TITLE
Revert "Bugfix: https://github.com/fraunhoferfokus/node-hbbtv/issues/4"

### DIFF
--- a/lib/hbbtv-dial-server.js
+++ b/lib/hbbtv-dial-server.js
@@ -166,7 +166,6 @@ var HbbTVDialServer = function (expressApp, isCsLauncher) {
         port: port,
         manufacturer: MANUFACTURER,
         modelName: MODEL_NAME,
-        cors_allow_origin: "*",
         delegate: {
             getApp: function(appName){
                 var app = apps[appName];


### PR DESCRIPTION
Reverts matt-hammond-bbc/node-hbbtv#1 ... because looks like fraunhofer prefer a different implementation approach that more precisely follows the DIAL specification.
